### PR TITLE
fix: missing authorization on plugin deactivation AJAX handler (CVE-2026-7622)

### DIFF
--- a/src/Deactivator.php
+++ b/src/Deactivator.php
@@ -132,6 +132,7 @@ class Deactivator {
 					<form method="post" class="pl-plugin-deactivation-survey-form">
 						<input type="hidden" name="plugin" value="" id="cxd-plugin-name">
 						<input type="hidden" name="action" value="pl-plugin-deactivation">
+						<?php wp_nonce_field( 'pl-plugin-deactivation-nonce', 'pl_deactivation_nonce' ); ?>
 						<div class="pl-plugin-dsm-header">
 							<h3 class="pl-heading">
 								<?php printf( __( 'We\'re so sorry to see you go, %s!', 'pluggable' ), $user->display_name ); ?>
@@ -171,6 +172,12 @@ class Deactivator {
 	}
 
 	public function send_deactivation_survey()	{
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			wp_send_json_error( 'Unauthorized', 403 );
+		}
+
+		check_ajax_referer( 'pl-plugin-deactivation-nonce', 'pl_deactivation_nonce' );
+
 		// deactivate the plugin first
 		deactivate_plugins( $this->basename );
 


### PR DESCRIPTION
## Summary

- **CVE-2026-7622** (Wordfence / CVSS 4.3 Medium): any authenticated user with Subscriber-level access could POST to `wp_ajax_pl-plugin-deactivation` and deactivate the plugin — no capability or nonce check existed.
- Add `current_user_can( 'activate_plugins' )` guard in `send_deactivation_survey()` → returns 403 for non-admins
- Add `check_ajax_referer( 'pl-plugin-deactivation-nonce', 'pl_deactivation_nonce' )` in `send_deactivation_survey()` → blocks CSRF
- Add `wp_nonce_field( 'pl-plugin-deactivation-nonce', 'pl_deactivation_nonce' )` to the modal form → legitimate admin submissions continue to work

## Affected file

`src/Deactivator.php`

## Test plan

- [ ] As admin: click Deactivate on plugins page → modal appears → Submit & Deactivate works normally
- [ ] As subscriber: POST directly to `admin-ajax.php` with `action=pl-plugin-deactivation` → receives 403 / `-1`, plugin stays active
- [ ] CSRF attempt (no nonce): POST without `pl_deactivation_nonce` field → `check_ajax_referer` kills request with `-1`